### PR TITLE
Replace abstract alphabet with integer alphabet

### DIFF
--- a/src/Bpp/Seq/Alphabet/ChromosomeAlphabet.cpp
+++ b/src/Bpp/Seq/Alphabet/ChromosomeAlphabet.cpp
@@ -34,7 +34,7 @@
 
 
 #include "ChromosomeAlphabet.h"
-#include "AbstractAlphabet.h"
+#include "IntegerAlphabet.h"
 #include "AlphabetState.h"
 
 // From Utils:
@@ -42,26 +42,22 @@
 
 using namespace bpp;
 
-ChromosomeAlphabet::ChromosomeAlphabet(unsigned int min, unsigned int max) : MIN_(min),MAX_(max), numOfCompositeStates_(0), compositeAlphabetMap_()
+ChromosomeAlphabet::ChromosomeAlphabet(unsigned int min, unsigned int max)
+  : IntegerAlphabet(max, min), // Explicitly call IntegerAlphabet constructor
+    MIN_(min),
+    MAX_(max),
+    numOfCompositeStates_(0),
+    compositeAlphabetMap_()
 {
   // Alphabet size definition
   //resize(MAX_);
-
-  // Alphabet content definition
-  registerState(new AlphabetState(-1, "-", "Gap"));
-
-  for (int i = static_cast<int>(MIN_); i < static_cast<int>(MAX_)+1; i++)
-  {
-    registerState(new AlphabetState(i, TextTools::toString(i), ""));
-  }
-  registerState(new AlphabetState(static_cast<int>(MAX_)+1, "X", "Unresolved state"));
 }
 
 const AlphabetState& ChromosomeAlphabet::getState(int num) const {
       if (num == 0){
         num = (int)MIN_;
       }
-      return(AbstractAlphabet::getState(num));
+      return(IntegerAlphabet::getState(num));
 
 }
 /********************************************************************************/

--- a/src/Bpp/Seq/Alphabet/ChromosomeAlphabet.h
+++ b/src/Bpp/Seq/Alphabet/ChromosomeAlphabet.h
@@ -35,7 +35,6 @@
 #ifndef BPP_SEQ_ALPHABET_CHROMOSOMEALPHABET_H
 #define BPP_SEQ_ALPHABET_CHROMOSOMEALPHABET_H
 
-#include "AbstractAlphabet.h"
 #include "IntegerAlphabet.h"
 #include <Bpp/Text/StringTokenizer.h>
 #include <Bpp/Text/TextTools.h>
@@ -55,7 +54,7 @@ namespace bpp
  *
  */
 class ChromosomeAlphabet :
-  public AbstractAlphabet
+  public IntegerAlphabet
 {
 private:
   unsigned int MIN_;
@@ -69,11 +68,11 @@ private:
 public:
   // class constructor
   ChromosomeAlphabet(unsigned int min, unsigned int max);
-  ChromosomeAlphabet(const ChromosomeAlphabet& bia) : AbstractAlphabet(bia), MIN_(bia.MIN_),MAX_(bia.MAX_), numOfCompositeStates_(0), compositeAlphabetMap_() {}
+  ChromosomeAlphabet(const ChromosomeAlphabet& bia) : IntegerAlphabet(bia), MIN_(bia.MIN_),MAX_(bia.MAX_), numOfCompositeStates_(0), compositeAlphabetMap_() {}
 
   ChromosomeAlphabet& operator=(const ChromosomeAlphabet& bia)
   {
-    AbstractAlphabet::operator=(bia);
+    IntegerAlphabet::operator=(bia);
     MIN_=bia.MIN_;
     MAX_=bia.MAX_;
     numOfCompositeStates_ = bia.numOfCompositeStates_;


### PR DESCRIPTION
This PR replaces the inherited class of `ChromosomeAlphabet` to `IntegerAlphabet` from `AbstractAlphabet`so we can use the basic chromosome substitution model on gene family data.